### PR TITLE
Changes to compilation flags

### DIFF
--- a/supercell-compression/cmake/lzham.cmake
+++ b/supercell-compression/cmake/lzham.cmake
@@ -102,7 +102,7 @@ target_precompile_headers(${LZHAM_TARGET} PUBLIC <cstdint>)
 target_compile_options(${LZHAM_TARGET} PRIVATE
     $<$<OR:${WK_GNU},${WK_CLANG}>: -Wall -Wextra -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64>
     $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_DEBUG}>: -g>
-    $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_RELEASE}>: -O3 -fomit-frame-pointer -fexpensive-optimizations -Wenum-compare-switch>
+    $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_RELEASE}>: -O3 -fomit-frame-pointer -fexpensive-optimizations -Wenum-compare>
 
     $<$<AND:${WK_MSVC},${WK_DEBUG}>: /RTC1>
     $<$<AND:${WK_MSVC},${WK_RELEASE}>: /GS- /Gy /fp:fast /W4 /Ox /Ob2 /Oi /Ot /Oy>

--- a/supercell-compression/cmake/lzham.cmake
+++ b/supercell-compression/cmake/lzham.cmake
@@ -92,7 +92,7 @@ target_compile_definitions(${LZHAM_TARGET} PRIVATE
 # flags for non-x64 systems
 if($<NOT:${WK_X64}>)
     target_compile_options(${LZHAM_TARGET} PRIVATE
-        $<${WK_GNU}: -m32>
+        $<$<OR:${WK_GNU},${WK_CLANG}>: -m32>
     )
 endif()
 
@@ -100,7 +100,7 @@ target_precompile_headers(${LZHAM_TARGET} PUBLIC <cstdint>)
 
 # compile options
 target_compile_options(${LZHAM_TARGET} PRIVATE
-    $<${WK_GNU}: -Wall -Wextra -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64>
+    $<$<OR:${WK_GNU},${WK_CLANG}>: -Wall -Wextra -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64>
     $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_DEBUG}>: -g>
     $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_RELEASE}>: -O3 -fomit-frame-pointer -fexpensive-optimizations -Wenum-compare-switch>
 

--- a/supercell-compression/cmake/lzham.cmake
+++ b/supercell-compression/cmake/lzham.cmake
@@ -102,7 +102,7 @@ target_precompile_headers(${LZHAM_TARGET} PUBLIC <cstdint>)
 target_compile_options(${LZHAM_TARGET} PRIVATE
     $<$<OR:${WK_GNU},${WK_CLANG}>: -Wall -Wextra -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64>
     $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_DEBUG}>: -g>
-    $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_RELEASE}>: -O3 -fomit-frame-pointer -fexpensive-optimizations -Wenum-compare>
+    $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_RELEASE}>: -O3 -Wenum-compare>
 
     $<$<AND:${WK_MSVC},${WK_DEBUG}>: /RTC1>
     $<$<AND:${WK_MSVC},${WK_RELEASE}>: /GS- /Gy /fp:fast /W4 /Ox /Ob2 /Oi /Ot /Oy>

--- a/supercell-compression/cmake/lzma.cmake
+++ b/supercell-compression/cmake/lzma.cmake
@@ -38,7 +38,7 @@ target_compile_definitions(${LZMA_TARGET} PRIVATE
 
 target_compile_options(${LZMA_TARGET} PRIVATE
     $<$<AND:${WK_MSVC},${WK_RELEASE}>: /Ox /GF /Gy /GS- /Ob2 /Oi /Ot>
-    $<$<AND:${WK_GNU},${WK_RELEASE}>: -c -O2 -Wall>
+    $<$<AND:$<OR:${WK_GNU},${WK_CLANG}>,${WK_RELEASE}>: -c -O2 -Wall>
 )
 
 # move into dependencies folder


### PR DESCRIPTION
Changes related to sc-workshop/workshop-core#2 and that only really make sense if that's merged first.

Now checks whether it's Clang as well, not just GNU.

Additionally removes `-fomit-frame-pointer` as O3 optimizations on both gcc and Clang remove frame pointers already. Also remove `-fexpensive-optimizations` as on gcc thats already enabled with O3 and on Clang that flag is not supported. Change `-Wenum-compare-switch`  to `-Wenum-compare` as `enum-compare-switch` is not a valid flag on gcc, but `enum-compare` is. On clang when `enum-compare`  is enabled, `enum-compare-switch` is also.