### PR TITLE
Properly bump ASTC Encoder version

### DIFF
--- a/supercell-compression/cmake/astc.cmake
+++ b/supercell-compression/cmake/astc.cmake
@@ -31,7 +31,7 @@ set(ASTCENC_CLI OFF)
 FetchContent_Declare(
     astcenc
     GIT_REPOSITORY https://github.com/ARM-software/astc-encoder
-    GIT_TAG 4.7.0
+    GIT_TAG ${ASTC_VERSION}
 )
 FetchContent_MakeAvailable(astcenc)
 


### PR DESCRIPTION
I think you meant to do this in 48aef11 however you forgot to change the tag to use the new variable. Notably this fixes the build error when using newer versions of clang (20 I believe) ARM-software/astc-encoder#500. Any version after 4.8.0 has the fix.